### PR TITLE
Disable unattended-upgrades

### DIFF
--- a/focal-rt-ros2/rootfs/setup/phase1.sh
+++ b/focal-rt-ros2/rootfs/setup/phase1.sh
@@ -48,6 +48,10 @@ cp /boot/initrd.img /boot/firmware/initrd.img.bak
 systemctl disable ondemand
 systemctl enable cpu-frequency
 
+
+# Disable unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades -fnoninteractive
+
 # TODO: If specified, create an image with isolcpus already setup.
 
 # Setup ROS distro and ROS

--- a/focal-rt-ros2/rootfs/setup/phase1.sh
+++ b/focal-rt-ros2/rootfs/setup/phase1.sh
@@ -50,7 +50,7 @@ systemctl enable cpu-frequency
 
 
 # Disable unattended-upgrades
-sudo dpkg-reconfigure -plow unattended-upgrades -fnoninteractive
+dpkg-reconfigure -plow unattended-upgrades -fnoninteractive
 
 # TODO: If specified, create an image with isolcpus already setup.
 


### PR DESCRIPTION
This PR disables unattended-upgrades so the kernel is not upgraded.

Signed-off-by: Carlos <carlos.sanvicente@apex.ai>