### PR TITLE
Updated focal kernel and get rid of hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ This is a custom image builder for the Raspberry Pi 4. Some features:
 ### Todos
 
 - [ ] Optionally configure isolcpus and nohz_full for the kernel.
-- [ ] Fix the issue with `LINUX_RT_VERSION` and `LINUX_RT_VERSION_ACTUALLY` (see `vars.sh`).
 - [ ] Use a sha256 checksum to ensure downloaded image and kernel are "secure".
 - [ ] Add overclocking support
 

--- a/image_builder/data/focal-rt/config.ini
+++ b/image_builder/data/focal-rt/config.ini
@@ -28,8 +28,7 @@ qemu_user_static_path = /usr/bin/qemu-aarch64-static
 # In fact, the build scripts from this profile will only have access to
 # environment variables declared for this profile.
 [env]
-LINUX_RT_VERSION = 5.4.106-rt54
-LINUX_RT_VERSION_ACTUALLY = 5.4.140-rt64
-STOCK_LINUX_VERSION = 5.4.0-1042
+LINUX_RT_VERSION = 5.4.195-rt74
+STOCK_LINUX_VERSION = 5.4.0-1052
 PINNED_CPU_FREQUENCY = 1500000
 

--- a/image_builder/data/focal-rt/scripts/phase1-host
+++ b/image_builder/data/focal-rt/scripts/phase1-host
@@ -7,14 +7,11 @@ pushd $CACHE_DIR
 # Get the kernel
 filename=rpi4-rt-kernel-${LINUX_RT_VERSION}.zip
 if [ ! -f $filename ]; then
-  wget --progress=dot -e dotbytes=10M -O $filename https://github.com/ros-realtime/rt-kernel-docker-builder/releases/download/v${LINUX_RT_VERSION}-raspi-arm64-lttng/RPI4.RT.Kernel.deb.packages.zip
+  wget --progress=dot -e dotbytes=10M -O $filename https://github.com/ros-realtime/linux-real-time-kernel-builder/releases/download/${LINUX_RT_VERSION}-raspi-arm64-lttng/RPI4.RT.Kernel.deb.packages.zip
 fi
 
 unzip $filename
 
-# Do not install the debug symbols as this causes an additional 3GB of storage
-# needed, which is will cause us to go over the 2GB limit for Github releases.
-rm linux*dbg*.deb
 ls -l
 
 # These deb files will be installed by the phase1 script.

--- a/image_builder/data/focal-rt/scripts/phase1-target
+++ b/image_builder/data/focal-rt/scripts/phase1-target
@@ -5,12 +5,17 @@ echo "PINNED_CPU_FREQUENCY=${PINNED_CPU_FREQUENCY}" > /etc/default/cpu-frequency
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Setting up PREEMPT_RT kernel
+cd /setup
+dpkg -i linux-*.deb
+rm linux-*.deb
+
 # Remove some packages that are likely not needed:
 # - snapd: no one packages their robot apps with snap, right?
 # - fwupd: I don't think we need to update devices firmware like a logitech mouse, and it also uses like 20MB of RAM...
 # - cryptsetup: don't need to setup disk encryption. Also, causes build failures on some host system configurations.
 # - mdadm: don't need to setup raid.
-# - Stock linux kernel: for obvious reasons
+# - Stock linux kernel: for obvious reasons.
 apt-get purge --autoremove -y \
   cryptsetup \
   fwupd \
@@ -26,19 +31,31 @@ apt-get purge --autoremove -y \
   btrfs-progs \
   xfsprogs
 
-# Setting up PREEMPT_RT kernel
-cd /setup
-sudo dpkg -i linux-*.deb
-rm linux-*.deb
+# TODO: Even tho
+# https://github.com/ros-realtime/linux-real-time-kernel-builder/pull/32 is
+# merged, this is still needed somehow... I suspect that flash-kernel is no
+# longer being called due to some changes upstream? Not sure.
+ln -s -f /boot/vmlinuz-${LINUX_RT_VERSION}-raspi /boot/vmlinuz
+ln -s -f /boot/initrd.img-${LINUX_RT_VERSION}-raspi /boot/initrd.img
 
-ln -s -f /boot/vmlinuz-${LINUX_RT_VERSION_ACTUALLY} /boot/vmlinuz
-ln -s -f /boot/initrd.img-${LINUX_RT_VERSION_ACTUALLY} /boot/initrd.img
-
-# TODO: This should be removable following https://github.com/ros-realtime/linux-real-time-kernel-builder/pull/32
 cp /boot/vmlinuz /boot/firmware/vmlinuz
-cp /boot/vmlinuz /boot/firmware/vmlinuz.bak
 cp /boot/initrd.img /boot/firmware/initrd.img
-cp /boot/initrd.img /boot/firmware/initrd.img.bak
+
+# Check to make sure that the kernel booted will be the RT kernel, not the
+# regular kernel. It is possible that the base image changed the kernel version
+# and STOCK_LINUX_VERSION is not updated here, which may result cause an error
+# here. If that happens, the STOCK_LINUX_VERSION must be updated. It is also
+# possible for something else to break this, in which case more investigations
+# would be needed.
+if [ "$(md5sum /boot/firmware/vmlinuz | cut -f 1 -d ' ')" != "$(md5sum /boot/vmlinuz-${LINUX_RT_VERSION}-raspi | cut -f 1 -d ' ')" ]; then
+  echo "ERROR: /boot/firmware/vmlinuz is not using the RT version, something is wrong with the build..."
+  exit 1
+fi
+
+if [ "$(md5sum /boot/firmware/initrd.img | cut -f 1 -d ' ')" != "$(md5sum /boot/initrd.img-${LINUX_RT_VERSION}-raspi | cut -f 1 -d ' ')" ]; then
+  echo "ERROR: /boot/firmware/initrd.img is not using the RT version, something is wrong with the build..."
+  exit 1
+fi
 
 # Disable ondemand govenor and set constant frequency
 systemctl disable ondemand


### PR DESCRIPTION
Following the [release of the new 5.4 kernel upstream](https://github.com/ros-realtime/linux-real-time-kernel-builder/releases/tag/5.4.195-rt74-raspi-arm64-lttng), the "ACTUALLY" hack can be removed from the focal image, because the kernel version inside the zip and the github release agrees. Further, there's no more need removing the dbg packages because they're not included in the new release.

It would be good if we can keep the git release tags constant.