### PR TITLE
Added `mount` `umount` command to mount and unmount existing image; Also added cmake toolchain for cross compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ There are two ways to use cross-compilation with this system:
    talks about this use case.
 
 
-To cross compile, you'll need to install this builder on the host machine via setuptools:
+To cross-compile, you'll need to install this builder on the host machine via setuptools:
 
 ```
 [host]$ sudo python3 setup.py install

--- a/docs/BuilderDesignAndUsageGuide.md
+++ b/docs/BuilderDesignAndUsageGuide.md
@@ -121,6 +121,45 @@ will then:
   the phase1 host scripts, the builder will run the script from the first
   profile, then the second, then the third, and so on.
 
+### Phase 2 cross-compilation
+
+If you want a custom image with a custom library/application, you can
+cross-compile it in phase2. This is done via a cross compilation toolchain
+installed on the host machine. An example of this is given in
+[`image_builder/data/example-cross-compile`](../image_builder/data/example-cross-compile).
+This is an example profile that can be overlaid ontop of any image and will
+cross-compile and install a C++ project. Please read this profile if you're
+interested in creating your own profile. Most C++ projects will follow a
+similar structure to it:
+
+1. The [`phase1-target`](../image_builder/data/example-cross-compile/scripts/phase1-target)
+   script installs the build and runtime dependency for the
+   project you're trying to cross compile into the target image.
+2. The [`phase2-host`](../image_builder/data/example-cross-compile/scripts/phase2-host)
+   script downloads the C++ project and calls to cmake. The
+   `CMAKE_TOOLCHAIN_FILE` is already passed to this script and points to
+   [`image_builder/data/toolchain.cmake`](../image_builder/data/toolchain.cmake)
+   so you shouldn't need to do anything special.
+
+Note: to run this successfully, you need to install the package
+`gcc-aarch64-linux-gnu g++-aarch64-linux-gnu` on your host system. This is
+because the toolchain file assumes your cross-compiler is at
+`/usr/bin/aarch64-linux-gnu-{gcc,g++}`.
+
+To run the example profile, build an image via the command:
+
+```
+sudo ./ros-rt-img build jammy-rt jammy-rt-humble example-cross-compile
+```
+
+This will install a few executable to the target image that will run on the
+Raspberry Pi.
+
+- `/bin/rt_simple_example`
+- `/bin/rt_message_passing_example`
+- `/bin/rt_mutex_example`
+- `/bin/rt_lttng_ust_example`
+
 Pause and resume
 ----------------
 

--- a/docs/BuilderDesignAndUsageGuide.md
+++ b/docs/BuilderDesignAndUsageGuide.md
@@ -127,7 +127,7 @@ If you want a custom image with a custom library/application, you can
 cross-compile it in phase2. This is done via a cross compilation toolchain
 installed on the host machine. An example of this is given in
 [`image_builder/data/example-cross-compile`](../image_builder/data/example-cross-compile).
-This is an example profile that can be overlaid ontop of any image and will
+This is an example profile that can be overlaid on top of any image and will
 cross-compile and install a C++ project. Please read this profile if you're
 interested in creating your own profile. Most C++ projects will follow a
 similar structure to it:

--- a/docs/BuilderDesignAndUsageGuide.md
+++ b/docs/BuilderDesignAndUsageGuide.md
@@ -134,7 +134,7 @@ similar structure to it:
 
 1. The [`phase1-target`](../image_builder/data/example-cross-compile/scripts/phase1-target)
    script installs the build and runtime dependency for the
-   project you're trying to cross compile into the target image.
+   project you're trying to cross-compile into the target image.
 2. The [`phase2-host`](../image_builder/data/example-cross-compile/scripts/phase2-host)
    script downloads the C++ project and calls to cmake. The
    `CMAKE_TOOLCHAIN_FILE` is already passed to this script and points to

--- a/image_builder/builder.py
+++ b/image_builder/builder.py
@@ -323,10 +323,14 @@ class Builder(object):
     # Preserve case sensitivity for configuration keys so that environment variables are properly exported.
     config.optionxform = str
     config.read(filename)
-    return (
-      dict(config["build"].items()),
-      dict(config["env"].items()),
-    )
+
+    # env is optional
+    try:
+      env = dict(config["env"].items())
+    except KeyError:
+      env = {}
+
+    return (dict(config["build"].items()), env)
 
   def _log_builder_information(self):
     # TODO: align the key and value to make the build output prettier.

--- a/image_builder/builder.py
+++ b/image_builder/builder.py
@@ -16,6 +16,7 @@ class RequirementNotMetError(RuntimeError):
 
 LOOP_DEVICE_FILENAME = "loop-device.txt"
 DEFAULT_CHROOT_PATH = "/tmp/rpi4-image-build"
+CMAKE_TOOLCHAIN_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data", "toolchain.cmake")
 
 
 class Builder(object):
@@ -267,7 +268,7 @@ class Builder(object):
 
   def run_phase2_host_scripts(self):
     for phase2_host_path in self.phase2_host_paths:
-      self._run_script_on_host(phase2_host_path)
+      self._run_script_on_host(phase2_host_path, more_env_vars={"CMAKE_TOOLCHAIN_FILE": CMAKE_TOOLCHAIN_FILE})
 
   def run_phase2_target_scripts(self):
     for phase2_target_path in self.phase2_target_paths:
@@ -381,10 +382,11 @@ class Builder(object):
     os.chmod(self.session_loop_device_file, 0o666)
     self._loop_device = loop_device
 
-  def _run_script_on_host(self, args: Sequence[str]|str, shell: bool = False):
+  def _run_script_on_host(self, args: Sequence[str]|str, shell: bool = False, more_env_vars: dict = {}):
     self.logger.debug(f"running {args} with env {self.env_vars}")
     env_vars = os.environ.copy() # So PATH still works...
     env_vars.update(self.env_vars)
+    env_vars.update(more_env_vars)
     if shell:
       # If there are pipe, it might mask a failure without pipefail.
       cmd = ["/bin/bash", "-o", "pipefail", "-c", args]

--- a/image_builder/builder.py
+++ b/image_builder/builder.py
@@ -14,12 +14,16 @@ class RequirementNotMetError(RuntimeError):
   pass
 
 
+LOOP_DEVICE_FILENAME = "loop-device.txt"
+DEFAULT_CHROOT_PATH = "/tmp/rpi4-image-build"
+
+
 class Builder(object):
   def __init__(self,
                profile_dirs: Sequence[str],
                cache_dir: str = "cache",
                out_dir: str = "out",
-               chroot_path: str = "/tmp/rpi4-image-build",
+               chroot_path: str = DEFAULT_CHROOT_PATH,
                pause_after: Union[str, None] = None):
     self.logger = logging.getLogger("builder")
 
@@ -29,7 +33,7 @@ class Builder(object):
     self.pause_after = pause_after
 
     self.session_file = os.path.join(self.cache_dir, "session.txt")
-    self.session_loop_device_file = os.path.join(self.cache_dir, "loop-device.txt")
+    self.session_loop_device_file = os.path.join(self.cache_dir, LOOP_DEVICE_FILENAME)
 
     self.build_vars = {}
     self.env_vars = {

--- a/image_builder/data/example-cross-compile/config.ini
+++ b/image_builder/data/example-cross-compile/config.ini
@@ -1,3 +1,2 @@
 [build]
 output_filename = example-cross-compile.img
-

--- a/image_builder/data/example-cross-compile/config.ini
+++ b/image_builder/data/example-cross-compile/config.ini
@@ -1,0 +1,3 @@
+[build]
+output_filename = example-cross-compile.img
+

--- a/image_builder/data/example-cross-compile/scripts/phase1-target
+++ b/image_builder/data/example-cross-compile/scripts/phase1-target
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -xe
+
+# Setup dependency for cross-compiling in phase2-host
+sudo apt-get update
+sudo apt-get install -y libspdlog-dev liblttng-ust-dev libboost-dev lttng-tools

--- a/image_builder/data/example-cross-compile/scripts/phase2-host
+++ b/image_builder/data/example-cross-compile/scripts/phase2-host
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -xe
+
+cd $CACHE_DIR
+
+rm -rf cactus-rt
+git clone https://github.com/cactusdynamics/cactus-rt.git
+cd cactus-rt
+
+# We can just run cmake, because CMAKE_TOOLCHAIN_FILE is already an environment
+# variable for this script only.
+echo $CMAKE_TOOLCHAIN_FILE
+cmake -Bbuild -DBUILD_TESTING=No
+cmake --build build -j $(nproc)
+
+# cmake --install will directly install the code into the image
+cmake --install build

--- a/image_builder/data/toolchain.cmake
+++ b/image_builder/data/toolchain.cmake
@@ -1,0 +1,15 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# TODO: this hard code is not great, but solving it comprehensively is kind of
+# difficult (maybe dockcross? but that has its own drawbacks..)
+set(CMAKE_SYSROOT /tmp/rpi4-image-build)
+
+# Assume host compiler, is that OK if host gcc version doesn't match target system gcc?
+set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/image_builder/data/toolchain.cmake
+++ b/image_builder/data/toolchain.cmake
@@ -4,6 +4,7 @@ set(CMAKE_SYSTEM_PROCESSOR aarch64)
 # TODO: this hard code is not great, but solving it comprehensively is kind of
 # difficult (maybe dockcross? but that has its own drawbacks..)
 set(CMAKE_SYSROOT /tmp/rpi4-image-build)
+set(CMAKE_STAGING_PREFIX /tmp/rpi4-image-build) # This allows phase2 to install directly to the image
 
 # Assume host compiler, is that OK if host gcc version doesn't match target system gcc?
 set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)

--- a/ros-rt-img
+++ b/ros-rt-img
@@ -3,9 +3,10 @@ import argparse
 import logging
 import subprocess
 import os
+import shutil
 import sys
 
-from image_builder.builder import Builder
+from image_builder.builder import Builder, LOOP_DEVICE_FILENAME, DEFAULT_CHROOT_PATH
 
 logging.basicConfig(format="[%(asctime)s][%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.DEBUG)
 
@@ -30,7 +31,7 @@ def parse_arguments():
 
   parser.add_argument(
     "--chroot-path",
-    default="/tmp/rpi4-image-build",
+    default=DEFAULT_CHROOT_PATH,
     help="The path the OS image will be mounted and chrooted at. Default: /tmp/rpi4-image-build"
   )
 
@@ -67,6 +68,11 @@ def parse_arguments():
 
   subparsers.add_parser("teardown", help="Reset the ongoing session (if any) and unmount the mounted image and teardown the loop device (if required)")
   subparsers.add_parser("chroot", help="Enters the chroot_path if possible")
+
+  mount_parser = subparsers.add_parser("mount", help="Mount a built image for interactive exploration and/or cross-compilation purposes. only works with Raspberry Pi Ubuntu images.")
+  mount_parser.add_argument("image", type=str, help="The path to the image to be mounted")
+
+  subparsers.add_parser("umount", help="unmount an image mounted for interaction via the mount sub-command")
 
   # Convert the action into a callable function.
   args = parser.parse_args()
@@ -122,6 +128,73 @@ def chroot(args):
     sys.exit(1)
 
   subprocess.run(["systemd-nspawn", "-D", args.chroot_path, "bash"])
+
+
+# TODO: there are some duplication with Builder.prepare_chroot and Builder.setup_loop_device_and_mount_partitions, but different enough that it is duplicated.
+def mount(args):
+  loop_device_cache_file = os.path.join(args.cache_dir, LOOP_DEVICE_FILENAME)
+  if os.path.exists(loop_device_cache_file):
+    logging.error("{} already exists, make sure no other build and mounts are in progress!".format(loop_device_cache_file))
+    sys.exit(1)
+
+  loop_device = subprocess.check_output(["losetup", "-P", "--show", "-f", args.image]).decode("utf-8").strip()
+  with open(loop_device_cache_file, "w") as f:
+    f.write(loop_device)
+
+  logging.info("setting up loop device on {}".format(loop_device))
+
+  os.chmod(loop_device_cache_file, 0o666) # since this script is root, set it to world writable so it can be more easily deleted
+
+  # TODO: this is kind of a hack, as the mount point for each partition is
+  # specified in the image_mounts in the config.ini. It is hard-coded for now
+  # as we assume the raspberry pi Ubuntu layout.
+  for i, mount_point in reversed(list(enumerate(["/boot/firmware", "/"]))):
+    i += 1
+    device_name = f"{loop_device}p{i}"
+    mount_point = os.path.join(args.chroot_path, mount_point.lstrip("/"))
+
+    logging.info("mounting {} to {}".format(device_name, mount_point))
+    subprocess.run(["mount", device_name, mount_point], check=True)
+
+  logging.info("copying resolv.conf and qemu-user-static")
+
+  shutil.move(
+    os.path.join(args.chroot_path, "etc", "resolv.conf"),
+    os.path.join(args.chroot_path, "etc", "resolv.conf.bak")
+  )
+
+  # TODO: also a hack, as qemu_user_static_path in the config.ini, but that's also a hack so...
+  qemu_user_static_path = "/usr/bin/qemu-aarch64-static"
+  shutil.copy(
+    qemu_user_static_path,
+    os.path.join(args.chroot_path, qemu_user_static_path.lstrip("/"))
+  )
+
+  shutil.copy(
+    "/etc/resolv.conf",
+    os.path.join(args.chroot_path, "etc", "resolv.conf")
+  )
+
+
+def umount(args):
+  os.remove(os.path.join(args.chroot_path, "etc", "resolv.conf"))
+  shutil.move(
+    os.path.join(args.chroot_path, "etc", "resolv.conf.bak"),
+    os.path.join(args.chroot_path, "etc", "resolv.conf"),
+  )
+
+  os.remove(os.path.join(args.chroot_path, "usr/bin/qemu-aarch64-static"))
+
+  subprocess.run(["umount", "-R", args.chroot_path], check=True)
+
+  loop_device_cache_file = os.path.join(args.cache_dir, LOOP_DEVICE_FILENAME)
+  if not os.path.exists(loop_device_cache_file):
+    logging.error("failed to detach loop device due to missing loop-device cache file, you'll have to manually call losetup -d")
+  else:
+    with open(loop_device_cache_file) as f:
+      loop_device = f.read().strip()
+
+    subprocess.run(["losetup", "-d", loop_device], check=True)
 
 
 def main():

--- a/ros-rt-img
+++ b/ros-rt-img
@@ -6,7 +6,7 @@ import os
 import shutil
 import sys
 
-from image_builder.builder import Builder, LOOP_DEVICE_FILENAME, DEFAULT_CHROOT_PATH
+from image_builder.builder import Builder, LOOP_DEVICE_FILENAME, DEFAULT_CHROOT_PATH, CMAKE_TOOLCHAIN_FILE
 
 logging.basicConfig(format="[%(asctime)s][%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.DEBUG)
 
@@ -74,6 +74,8 @@ def parse_arguments():
 
   subparsers.add_parser("umount", help="unmount an image mounted for interaction via the mount sub-command")
 
+  subparsers.add_parser("toolchain", help="prints the path to the cmake toolchain location")
+
   # Convert the action into a callable function.
   args = parser.parse_args()
   args.action = globals()[args.action]
@@ -97,7 +99,7 @@ def teardown(args):
   # profile directories, so that code from here and from clean can be reused.
 
   session_file = os.path.join(args.cache_dir, "session.txt")
-  session_loop_device_file = os.path.join(args.cache_dir, "loop-device.txt")
+  session_loop_device_file = os.path.join(args.cache_dir, LOOP_DEVICE_FILENAME)
 
   if os.path.isfile(session_loop_device_file):
     with open(session_loop_device_file) as f:
@@ -195,6 +197,11 @@ def umount(args):
       loop_device = f.read().strip()
 
     subprocess.run(["losetup", "-d", loop_device], check=True)
+    os.remove(loop_device_cache_file)
+
+
+def toolchain(args):
+  print(CMAKE_TOOLCHAIN_FILE)
 
 
 def main():


### PR DESCRIPTION
Resolves #17 and #39

What's added here is two ways to do cross compilation:

1. Cross compilation in the phase2 script (phase2 cross-compile) so application can be directly built into the image. I have an example of this in this PR as an overlay profile you can overlay on either the focal/jammy images. This profile is not enabled by default in the Makefile so the artifacts built for demonstration purposes do not leak into our "production" focal/jammy images.
2. Interactive cross-compilation by remounting the image after it is built. This allows you to build a project and then ship the binary to a target via ssh for example (second use case as written in #17) 

I tested the interactive cross-compilation via the instructions I wrote in the README.md and found that it works with [`cactus-rt` (previously named shuhaowu/rt-demo)](https://github.com/cactusdynamics/cactus-rt). Here are the outputs of the binary I scp'ed to the Pi after building on my desktop:

```
ubuntu@ubuntu:/app/examples/mutex_example$ ./rt_mutex_example 
a is 2
[2022-08-17 22:37:08.101] [debug] [app.cc:13] Starting application
[2022-08-17 22:37:08.113] [debug] [thread.cc:16] starting the RT thread RTThread
  +2.51892 +2518.92 -0.999717 -9.99717
```

Phase 2 compile works as well, and there's an example output in the build logs. Docs are written as well.

```
+ cmake --build build -j 16
[  6%] Building CXX object CMakeFiles/cactus_rt.dir/src/app.cc.o
[ 20%] Building CXX object CMakeFiles/cactus_rt.dir/src/latency_tracker.cc.o
[ 20%] Building CXX object CMakeFiles/cactus_rt.dir/src/thread.cc.o
[ 26%] Linking CXX static library libcactus_rt.a
[ 26%] Built target cactus_rt
[ 40%] Building CXX object examples/message_passing_example/CMakeFiles/rt_message_passing_example.dir/src/main.cc.o
[ 46%] Building CXX object examples/message_passing_example/CMakeFiles/rt_message_passing_example.dir/src/data_logger.cc.o
[ 53%] Building CXX object examples/lttng_ust_example/CMakeFiles/rt_lttng_ust_example.dir/src/tracepoint_provider.cc.o
[ 53%] Building CXX object examples/mutex_example/CMakeFiles/rt_mutex_example.dir/src/main.cc.o
[ 60%] Building CXX object examples/lttng_ust_example/CMakeFiles/rt_lttng_ust_example.dir/src/main.cc.o
[ 66%] Building CXX object examples/simple_example/CMakeFiles/rt_simple_example.dir/main.cc.o
[ 73%] Building CXX object examples/message_passing_example/CMakeFiles/rt_message_passing_example.dir/src/rt_thread.cc.o
[ 80%] Linking CXX executable rt_mutex_example
[ 80%] Built target rt_mutex_example
[ 86%] Linking CXX executable rt_lttng_ust_example
[ 86%] Built target rt_lttng_ust_example
[ 93%] Linking CXX executable rt_message_passing_example
[ 93%] Built target rt_message_passing_example
[100%] Linking CXX executable rt_simple_example
[100%] Built target rt_simple_example
+ cmake --install build
-- Install configuration: ""
-- Installing: /tmp/rpi4-image-build/bin/rt_simple_example
-- Installing: /tmp/rpi4-image-build/bin/rt_message_passing_example
-- Installing: /tmp/rpi4-image-build/bin/rt_mutex_example
-- Installing: /tmp/rpi4-image-build/bin/rt_lttng_ust_example
```