### PR TITLE
Added beginner docs for using the Raspberry Pi 4 ROS image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,79 @@
-Custom Image Builder for the Raspberry Pi 4 for ROS2 + PREEMPT_RT
-=================================================================
+Raspberry Pi image with ROS2 and the real-time kernel
+=====================================================
 
 [![Build image](https://github.com/ros-realtime/ros-realtime-rpi4-image/actions/workflows/build.yml/badge.svg)](https://github.com/ros-realtime/ros-realtime-rpi4-image/actions/workflows/build.yml)
+
+This repo builds a Raspberry Pi 3/4/400 image with ROS2 and the real-time kernel
+pre-installed.  This image can be downloaded directly from [the releases
+page](https://github.com/ros-realtime/ros-realtime-rpi4-image/releases),
+flashed to a SD card, and booted on a Raspberry Pi 3/4/400.
+
+How to
+------
+
+Before you start, you need a SD card that is at least 8GB in size.
+
+1. Download the desired image from [the releases page](https://github.com/ros-realtime/ros-realtime-rpi4-image/releases).
+2. The image is compressed with the `xz` compression format. You will need to
+   decompress it. On Windows, try using [7-zip](https://www.7-zip.org/) to do
+   this if your file archiver doesn't decompress this format already. Once
+   decompressed, you should have a file that ends with the extension `.img`.
+    1. On Mac/Linux, use `xz --decompress file.img.xz` in the command line.
+3. The easiest way to flash the image is via the [Raspberry Pi imager](https://www.raspberrypi.com/software/). 
+    1. Using the Raspberry Pi Image, click `CHOOSE OS`.
+    2. Scroll all the way down and click `Use custom`.
+    3. Browse and select the image file.
+    4. Select the storage device.
+    5. Click `Write` to flash the image.
+    6. Wait for it to be done.
+4. Unplug the SD card and plug it into the Raspberry Pi 3/4/400. Turn on the
+   Raspberry Pi.
+5. The default username is `ubuntu` and the password is `ubuntu`. The default
+   hostname is `ubuntu`. You can login either directly on the Raspberry Pi or
+   via SSH (enabled by default). You'll need to change your password the first
+   time you login.
+6. To save space, the image does not have the desktop environment installed. If
+   you want a desktop environment, you must install it with the following three
+   commands:
+
+```
+sudo apt update && sudo apt upgrade
+sudo apt install ubuntu-desktop
+sudo apt install ros-humble-desktop
+```
+
+7. You can now use ROS. To confirm, type `ros2` into the terminal. You should
+   see:
+
+```
+usage: ros2 [-h] [--use-python-default-buffering] Call `ros2 <command> -h` for more detailed usage. ...
+
+ros2 is an extensible command-line tool for ROS 2.
+
+options:
+  -h, --help            show this help message and exit
+
+  [...omitted for brevity]
+```
+
+8. The setup is now complete! 🎉 You can follow the rest of the [ROS2 tutorials
+   here](https://docs.ros.org/en/humble/Tutorials.html).
+
+Bonus setup
+-----------
+
+- [Setup WiFi without a GUI](https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#3-wifi-or-ethernet).
+- [Overclocking the CPU](https://magpi.raspberrypi.com/articles/how-to-overclock-raspberry-pi-4).
+  I've had good luck with `arm_freq=2000` and `over_voltage=6` when using power
+  supplies that can consistently output 5V/3A (like the official power supply).
+- Try out real-time programming with the following resources:
+  - [(1)](https://docs.ros.org/en/humble/Tutorials/Demos/Real-Time-Programming.html), [(2)](https://ros-realtime.github.io/Resources/resources.html), [(3)](https://shuhaowu.com/blog/2022/01-linux-rt-appdev-part1.html), [(4)](https://wiki.linuxfoundation.org/realtime/documentation/howto/applications/start)
+
+The rest of this README is meant for developers who want to know more about the
+image builder.
+
+Custom Image Builder for the Raspberry Pi for ROS2 + PREEMPT_RT
+===============================================================
 
 This is a custom image builder for the Raspberry Pi 4. Some features:
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-Raspberry Pi image with ROS2 and the real-time kernel
+Raspberry Pi image with ROS 2 and the real-time kernel
 =====================================================
 
 [![Build image](https://github.com/ros-realtime/ros-realtime-rpi4-image/actions/workflows/build.yml/badge.svg)](https://github.com/ros-realtime/ros-realtime-rpi4-image/actions/workflows/build.yml)
 
-This repo builds a Raspberry Pi 3/4/400 image with ROS2 and the real-time kernel
-pre-installed.  This image can be downloaded directly from [the releases
+This repo builds a Raspberry Pi 4 image with ROS 2 and the real-time kernel
+pre-installed. This image can be downloaded directly from [the releases
 page](https://github.com/ros-realtime/ros-realtime-rpi4-image/releases),
-flashed to a SD card, and booted on a Raspberry Pi 3/4/400.
+flashed to a SD card, and booted on a Raspberry Pi 4.
 
 How to
 ------
 
-Before you start, you need a SD card that is at least 8GB in size.
+Before you start, you need an SD card that is at least 8GB in size.
 
 1. Download the desired image from [the releases page](https://github.com/ros-realtime/ros-realtime-rpi4-image/releases).
 2. The image is compressed with the `xz` compression format. You will need to
    decompress it. On Windows, try using [7-zip](https://www.7-zip.org/) to do
    this if your file archiver doesn't decompress this format already. Once
    decompressed, you should have a file that ends with the extension `.img`.
-    1. On Mac/Linux, use `xz --decompress file.img.xz` in the command line.
+    1. On Mac/GNU-Linux, use `xz --decompress file.img.xz` in the command line.
 3. The easiest way to flash the image is via the [Raspberry Pi imager](https://www.raspberrypi.com/software/). 
     1. Using the Raspberry Pi Image, click `CHOOSE OS`.
     2. Scroll all the way down and click `Use custom`.
@@ -26,7 +26,7 @@ Before you start, you need a SD card that is at least 8GB in size.
     4. Select the storage device.
     5. Click `Write` to flash the image.
     6. Wait for it to be done.
-4. Unplug the SD card and plug it into the Raspberry Pi 3/4/400. Turn on the
+4. Unplug the SD card and plug it into the Raspberry Pi 4. Turn on the
    Raspberry Pi.
 5. The default username is `ubuntu` and the password is `ubuntu`. The default
    hostname is `ubuntu`. You can login either directly on the Raspberry Pi or
@@ -42,7 +42,7 @@ sudo apt install ubuntu-desktop
 sudo apt install ros-humble-desktop
 ```
 
-7. You can now use ROS. To confirm, type `ros2` into the terminal. You should
+7. You can now use ROS 2. To confirm, type `ros2` into the terminal. You should
    see:
 
 ```
@@ -56,8 +56,8 @@ options:
   [...omitted for brevity]
 ```
 
-8. The setup is now complete! 🎉 You can follow the rest of the [ROS2 tutorials
-   here](https://docs.ros.org/en/humble/Tutorials.html).
+8. The setup is now complete!  You can follow the rest of the [ROS 2 tutorials
+   here](https://docs.ros.org/en/rolling/Tutorials.html).
 
 Bonus setup
 -----------
@@ -72,7 +72,7 @@ Bonus setup
 The rest of this README is meant for developers who want to know more about the
 image builder.
 
-Custom Image Builder for the Raspberry Pi for ROS2 + PREEMPT_RT
+Custom Image Builder for the Raspberry Pi for ROS 2 + PREEMPT_RT
 ===============================================================
 
 This is a custom image builder for the Raspberry Pi 4. Some features:


### PR DESCRIPTION
Added docs at the top of the readme so that beginners can get started with the image. 

This is needed before ROScon 2022 so we can fulfill all our promises.

Resolves #51