### PR TITLE
Bumped jammy-humble to 22.04.3

### DIFF
--- a/image_builder/data/jammy-rt-humble/config.ini
+++ b/image_builder/data/jammy-rt-humble/config.ini
@@ -1,7 +1,7 @@
 # Overrides the variables in focal-rt/config.ini. See that file for a more
 # comprehensive example.
 [build]
-output_filename = ubuntu-22.04.1-rt-ros2-arm64+raspi.img
+output_filename = ubuntu-22.04.3-rt-ros2-arm64+raspi.img
 
 [env]
 ROS_DISTRO = humble

--- a/image_builder/data/jammy-rt/config.ini
+++ b/image_builder/data/jammy-rt/config.ini
@@ -2,7 +2,7 @@
 # can be overwritten by profiles overlaid on top of this one.
 [build]
 # The image url to download and customize.
-image_url = https://cdimage.ubuntu.com/ubuntu/releases/22.04/release/ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz
+image_url = https://cdimage.ubuntu.com/ubuntu/releases/22.04/release/ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz
 
 # Mount location for the partitions in the image file downloaded.
 image_mounts = /boot/firmware,/
@@ -12,7 +12,7 @@ image_mounts = /boot/firmware,/
 image_size = 4G
 
 # The filename of the output image
-output_filename = ubuntu-22.04.1-rt-arm64+raspi.img
+output_filename = ubuntu-22.04.3-rt-arm64+raspi.img
 
 # TODO: this shouldn't really be a part of the build configuration, because it
 # is more like a host-level configuration. Instead of putting it here, it should
@@ -29,6 +29,6 @@ qemu_user_static_path = /usr/bin/qemu-aarch64-static
 # environment variables declared for this profile.
 [env]
 LINUX_RT_VERSION = 5.15.39-rt42
-STOCK_LINUX_VERSION = 5.15.0-1005
+STOCK_LINUX_VERSION = 5.15.0-1034
 PINNED_CPU_FREQUENCY = 1500000
 


### PR DESCRIPTION
22.04.1 is not longer available so the builder no longer builds. Updated to 22.04.3 and things are OK again.

I'm not planning to do a full release until we get a new kernel, tho.